### PR TITLE
update peerDependencies for react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/wangzuo/react-input-slider",
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.0.2",
+    "react-dom": "^15.0.2"
   },
   "devDependencies": {
     "babel-core": "^6.1.2",


### PR DESCRIPTION
There is a new reactjs version and the current peerDependencies setup of react-input-slider
 forbids to install it.

We tested it with v. 15.0.2, not with the latest (v.15.1.0) reactjs release.
