### PR TITLE
Force non-passive event for touch device

### DIFF
--- a/lib/input-slider.js
+++ b/lib/input-slider.js
@@ -145,7 +145,7 @@ class InputSlider extends Component {
     document.addEventListener('mousemove', this.handleDrag);
     document.addEventListener('mouseup', this.handleDragEnd);
 
-    document.addEventListener('touchmove', this.handleDrag);
+    document.addEventListener('touchmove', this.handleDrag, { passive: false });
     document.addEventListener('touchend', this.handleDragEnd);
     document.addEventListener('touchcancel', this.handleDragEnd);
   };


### PR DESCRIPTION
Touch event listeners had a breaking change in chrome 56. Passive events became the default in Chrome 56 and up. This PR's forces the listener to be non-passive, so that `preventDefault` is no longer being ignored. Without it, the page wants to navigate to the next / previous page when swiping on a touch screen.

See: https://developers.google.com/web/updates/2017/01/scrolling-intervention
Related: facebook/react/#8968