### PR TITLE
add props to onChange parameters

### DIFF
--- a/lib/input-slider.js
+++ b/lib/input-slider.js
@@ -135,7 +135,7 @@ class InputSlider extends Component {
     const x = (dx !== 0 ? parseInt(dx / xstep, 10) * xstep : 0) + xmin;
     const y = (dy !== 0 ? parseInt(dy / ystep, 10) * ystep : 0) + ymin;
 
-    this.props.onChange({ x: x, y: y });
+    this.props.onChange({ x: x, y: y }, this.props);
   };
 
   handleMouseDown = e => {


### PR DESCRIPTION
Hey,

I have an use case where I'm using the slider change [HSL/RGB](https://colormeup.co/) parameters individually and I need to know which slider was changed.

The easiest way was to pass the name (R/G/B) as a data property and get that back on the onChange callback as a second parameter.