### PR TITLE
Pass position to onDragEnd rather than the default event

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -131,7 +131,7 @@ const Slider = ({
     document.removeEventListener('touchcancel', handleDragEnd);
 
     if (onDragEnd) {
-      onDragEnd(e);
+      onDragEnd(getPos(e));
     }
   }
 


### PR DESCRIPTION
I don't see why the default event is interesting here. In my usecase I needed the current value to process it in `onDragEnd()`